### PR TITLE
Added package information for projects

### DIFF
--- a/src/NinjaCsv.Common/NinjaCsv.Common.csproj
+++ b/src/NinjaCsv.Common/NinjaCsv.Common.csproj
@@ -2,6 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Authors>Ninja Software Consulting</Authors>
+    <Product>NinjaCsv.Common</Product>
+    <Description>The common features used between internal and public features</Description>
+    <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/ninjacoder88/ninja-csv.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
 </Project>

--- a/src/NinjaCsv.Internal/NinjaCsv.Internal.csproj
+++ b/src/NinjaCsv.Internal/NinjaCsv.Internal.csproj
@@ -2,6 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Authors>Ninja Software Consulting</Authors>
+    <Description>The internal features consumed by NinjaCsv</Description>
+    <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/ninjacoder88/ninja-csv.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In order for NinjaCsv to be able to be downloaded on NuGet, the dependencies of *.Common and *.Internal needed to be pushed to NuGet as unlisted pakages